### PR TITLE
Fix code scanning alert no. 85: Template Object Injection

### DIFF
--- a/routes/dataErasure.ts
+++ b/routes/dataErasure.ts
@@ -70,7 +70,8 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       const isForbiddenFile: boolean = (filePath.includes('ftp') || filePath.includes('ctf.key') || filePath.includes('encryptionkeys'))
       if (!isForbiddenFile) {
         res.render('dataErasureResult', {
-          ...req.body
+          email: req.body.email,
+          securityAnswer: req.body.securityAnswer
         }, (error, html) => {
           if (!html || error) {
             next(new Error(error.message))
@@ -85,7 +86,8 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       }
     } else {
       res.render('dataErasureResult', {
-        ...req.body
+        email: req.body.email,
+        securityAnswer: req.body.securityAnswer
       })
     }
   } catch (error) {


### PR DESCRIPTION
Fixes [https://github.com/zjaveed-sand-org/juice-shop-24oct/security/code-scanning/85](https://github.com/zjaveed-sand-org/juice-shop-24oct/security/code-scanning/85)

To fix the problem, we need to avoid passing the entire `req.body` object to the template engine. Instead, we should explicitly construct an object with only the specific properties needed by the template. This approach ensures that only the intended data is used in the template rendering process, mitigating the risk of template object injection.

In the file `routes/dataErasure.ts`, we need to modify the code to construct an object with the required properties (`email` and `securityAnswer`) from `req.body` and pass this object to the `res.render` function. This change should be applied to both instances where `res.render` is called with `req.body`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
