### PR TITLE
Fix code scanning alert no. 28: Database query built from user-controlled sources

### DIFF
--- a/routes/updateProductReviews.ts
+++ b/routes/updateProductReviews.ts
@@ -15,7 +15,7 @@ module.exports = function productReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     const user = security.authenticatedUsers.from(req) // vuln-code-snippet vuln-line forgedReviewChallenge
     db.reviews.update( // vuln-code-snippet neutral-line forgedReviewChallenge
-      { _id: req.body.id }, // vuln-code-snippet vuln-line noSqlReviewsChallenge forgedReviewChallenge
+      { _id: { $eq: req.body.id } }, // vuln-code-snippet vuln-line noSqlReviewsChallenge forgedReviewChallenge
       { $set: { message: req.body.message } },
       { multi: true } // vuln-code-snippet vuln-line noSqlReviewsChallenge
     ).then(


### PR DESCRIPTION
Fixes [https://github.com/zjaveed-sand-org/juice-shop-24oct/security/code-scanning/28](https://github.com/zjaveed-sand-org/juice-shop-24oct/security/code-scanning/28)

To fix the problem, we need to ensure that the user input is interpreted as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This approach ensures that the input is treated as a literal value, preventing NoSQL injection attacks.

We will modify the query on line 18 to use the `$eq` operator. No additional imports or definitions are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
