### PR TITLE
Fix code scanning alert no. 27: Database query built from user-controlled sources

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -20,7 +20,9 @@ module.exports = function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
     let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
-    models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
+    models.sequelize.query('SELECT * FROM Products WHERE ((name LIKE :criteria OR description LIKE :criteria) AND deletedAt IS NULL) ORDER BY name', {
+      replacements: { criteria: `%${criteria}%` }
+    }) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {
         const dataString = JSON.stringify(products)
         if (challengeUtils.notSolved(challenges.unionSqlInjectionChallenge)) { // vuln-code-snippet hide-start


### PR DESCRIPTION
Fixes [https://github.com/zjaveed-sand-org/juice-shop-24oct/security/code-scanning/27](https://github.com/zjaveed-sand-org/juice-shop-24oct/security/code-scanning/27)

To fix the problem, we should use parameterized queries to safely embed the user input into the SQL query. This approach prevents SQL injection by treating user input as data rather than executable code. In Sequelize, we can use the `replacements` option to safely include user input in the query.

- Modify the SQL query to use placeholders for the user input.
- Use the `replacements` option to pass the user input as parameters to the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
